### PR TITLE
Fix instructions for installing phpmyadmin tables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,12 @@ PhpMyAdmin runs on localhost:8001 by default. But it has no place to store it's
 settings yet. You can fix that by loging in at the phpmyadmin console and run:
 
 ```
+# in host
+docker exec -it --user root go_phpmyadmin sh
+# in container
 apk update
 apk add mysql-client
-mysql -u root -pgroupoffice -h db phpmyadmin < /www/sql/create_tables.sql
+mysql -u root -pgroupoffice -h db < /www/sql/create_tables.sql
 ```
 
 Now recreate the containers:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ PhpMyAdmin runs on localhost:8001 by default. But it has no place to store it's
 settings yet. You can fix that by running:
 
 ```sh
-# in host (logs into the correct docker container)
+# in host (login to the correct docker container)
 docker exec -it --user root go_phpmyadmin sh
 # in container
 apk update # update the package database

--- a/README.md
+++ b/README.md
@@ -67,15 +67,15 @@ PhpMyAdmin
 ----------
 
 PhpMyAdmin runs on localhost:8001 by default. But it has no place to store it's
-settings yet. You can fix that by loging in at the phpmyadmin console and run:
+settings yet. You can fix that by running:
 
-```
-# in host
+```sh
+# in host (logs into the correct docker container)
 docker exec -it --user root go_phpmyadmin sh
 # in container
-apk update
-apk add mysql-client
-mysql -u root -pgroupoffice -h db < /www/sql/create_tables.sql
+apk update # update the package database
+apk add mysql-client # get a mysql client for running sql
+mysql -u root -pgroupoffice -h db < /www/sql/create_tables.sql # create the database
 ```
 
 Now recreate the containers:


### PR DESCRIPTION
In the line `mysql -u root -pgroupoffice -h db < /www/sql/create_tables.sql` if you specify a database (`phpmyadmin`) then the script will fail if the database doesn't exist. If you don't specify the database, then a `use phpmyadmin` in the script makes sure you are using the correct database, so it will run correctly.