### PR TITLE
[FIX] MARIADB_AUTO_UPGRADE configuration error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - "8306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: groupoffice
-      MARIADB_AUTO_UPGRADE: true
+      MARIADB_AUTO_UPGRADE: 1
     env_file:
       - ./db.env     
 


### PR DESCRIPTION
While we launch, for the first time "docker-compose up -d", we have an error : `The Compose file './../../docker-compose.yml' is invalid because: services.db.environment.MARIADB_AUTO_UPGRADE contains true, which is an invalid type, it should be a string, number, or a null`